### PR TITLE
Change clone depth to 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,6 @@ before_cache:
 branches:
   only:
     - "master"
+
+git:
+  depth: 5


### PR DESCRIPTION
By default Travis CI clones the last 50 commits. Cloning less means faster checkout and clone times which results in slightly faster builds.

See [the docs](https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth) for more information.